### PR TITLE
Update pom versions to initial value

### DIFF
--- a/integrations/applications/single-page-application/info.json
+++ b/integrations/applications/single-page-application/info.json
@@ -1,7 +1,6 @@
 {
     "id": "single-page-application",
     "name": "Single-Page Application",
-    "version": "${project.version}",
     "description": "A web application that runs application logic in the browser.",
     "image": "${CONSOLE_BASE_URL}/resources/applications/assets/images/illustrations/spa-template.svg",
     "displayOrder": 0,

--- a/integrations/applications/traditional-web-application/info.json
+++ b/integrations/applications/traditional-web-application/info.json
@@ -1,6 +1,5 @@
 {
     "id": "traditional-web-application",
-    "version": "${project.version}",
     "name": "Traditional Web Application",
     "description": "A web application that runs application logic on the server.",
     "image": "${CONSOLE_BASE_URL}/resources/applications/assets/images/illustrations/traditional-template.svg",

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -28,7 +28,7 @@
     <artifactId>identity-inetgration-ui-templates</artifactId>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
-    <version>0.0.3-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
 
     <scm>
         <url>https://github.com/wso2-extensions/identity-integration-ui-templates.git</url>


### PR DESCRIPTION
## Purpose
- During the testing phase, we used a 0-based POM version; this update will set the POM version to the initial snapshot version.
- Remove the `project.version` field from `info.json` files.

## Related Issue
- https://github.com/wso2/product-is/issues/20107