### PR TITLE
[Testing-6] Remove the maven-assembly plugin

### DIFF
--- a/integrations/applications/custom-application/pom.xml
+++ b/integrations/applications/custom-application/pom.xml
@@ -35,48 +35,14 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>get-zip-root-dir-path</id>
-                        <goals>
-                            <goal>regex-property</goal>
-                        </goals>
-                        <configuration>
-                            <name>zip.root.dir.path</name>
-                            <regex>.*/([^/]+/[^/]+)$</regex>
-                            <value>${project.basedir}</value>
-                            <replacement>$1</replacement>
-                            <failIfNoMatch>true</failIfNoMatch>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                    <descriptors>
-                        <descriptor>zip.xml</descriptor>
-                    </descriptors>
-                    <appendAssemblyId>false</appendAssemblyId>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>make-assembly</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <artifactId>maven-antrun-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <preparationGoals>clean install</preparationGoals>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/integrations/applications/custom-application/pom.xml
+++ b/integrations/applications/custom-application/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.integration.ui.templates</groupId>
         <artifactId>integration-templates</artifactId>
         <version>1.0.3-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     
     <name>custom-application</name>

--- a/integrations/applications/custom-protocol-application/pom.xml
+++ b/integrations/applications/custom-protocol-application/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.integration.ui.templates</groupId>
         <artifactId>integration-templates</artifactId>
         <version>1.0.3-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     
     <name>custom-protocol-application</name>

--- a/integrations/applications/custom-protocol-application/pom.xml
+++ b/integrations/applications/custom-protocol-application/pom.xml
@@ -35,48 +35,14 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>get-zip-root-dir-path</id>
-                        <goals>
-                            <goal>regex-property</goal>
-                        </goals>
-                        <configuration>
-                            <name>zip.root.dir.path</name>
-                            <regex>.*/([^/]+/[^/]+)$</regex>
-                            <value>${project.basedir}</value>
-                            <replacement>$1</replacement>
-                            <failIfNoMatch>true</failIfNoMatch>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                    <descriptors>
-                        <descriptor>zip.xml</descriptor>
-                    </descriptors>
-                    <appendAssemblyId>false</appendAssemblyId>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>make-assembly</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <artifactId>maven-antrun-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <preparationGoals>clean install</preparationGoals>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/integrations/applications/m2m-application/pom.xml
+++ b/integrations/applications/m2m-application/pom.xml
@@ -35,48 +35,14 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>get-zip-root-dir-path</id>
-                        <goals>
-                            <goal>regex-property</goal>
-                        </goals>
-                        <configuration>
-                            <name>zip.root.dir.path</name>
-                            <regex>.*/([^/]+/[^/]+)$</regex>
-                            <value>${project.basedir}</value>
-                            <replacement>$1</replacement>
-                            <failIfNoMatch>true</failIfNoMatch>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                    <descriptors>
-                        <descriptor>zip.xml</descriptor>
-                    </descriptors>
-                    <appendAssemblyId>false</appendAssemblyId>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>make-assembly</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <artifactId>maven-antrun-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <preparationGoals>clean install</preparationGoals>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/integrations/applications/m2m-application/pom.xml
+++ b/integrations/applications/m2m-application/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.integration.ui.templates</groupId>
         <artifactId>integration-templates</artifactId>
         <version>1.0.3-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     
     <name>m2m-application</name>

--- a/integrations/applications/mobile-application/pom.xml
+++ b/integrations/applications/mobile-application/pom.xml
@@ -35,48 +35,14 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>get-zip-root-dir-path</id>
-                        <goals>
-                            <goal>regex-property</goal>
-                        </goals>
-                        <configuration>
-                            <name>zip.root.dir.path</name>
-                            <regex>.*/([^/]+/[^/]+)$</regex>
-                            <value>${project.basedir}</value>
-                            <replacement>$1</replacement>
-                            <failIfNoMatch>true</failIfNoMatch>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                    <descriptors>
-                        <descriptor>zip.xml</descriptor>
-                    </descriptors>
-                    <appendAssemblyId>false</appendAssemblyId>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>make-assembly</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <artifactId>maven-antrun-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <preparationGoals>clean install</preparationGoals>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/integrations/applications/mobile-application/pom.xml
+++ b/integrations/applications/mobile-application/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.integration.ui.templates</groupId>
         <artifactId>integration-templates</artifactId>
         <version>1.0.3-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     
     <name>mobile-application</name>

--- a/integrations/applications/single-page-application/pom.xml
+++ b/integrations/applications/single-page-application/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.integration.ui.templates</groupId>
         <artifactId>integration-templates</artifactId>
         <version>1.0.3-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     
     <name>single-page-application</name>

--- a/integrations/applications/single-page-application/pom.xml
+++ b/integrations/applications/single-page-application/pom.xml
@@ -35,48 +35,14 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>get-zip-root-dir-path</id>
-                        <goals>
-                            <goal>regex-property</goal>
-                        </goals>
-                        <configuration>
-                            <name>zip.root.dir.path</name>
-                            <regex>.*/([^/]+/[^/]+)$</regex>
-                            <value>${project.basedir}</value>
-                            <replacement>$1</replacement>
-                            <failIfNoMatch>true</failIfNoMatch>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                    <descriptors>
-                        <descriptor>zip.xml</descriptor>
-                    </descriptors>
-                    <appendAssemblyId>false</appendAssemblyId>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>make-assembly</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <artifactId>maven-antrun-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <preparationGoals>clean install</preparationGoals>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/integrations/applications/traditional-web-application/pom.xml
+++ b/integrations/applications/traditional-web-application/pom.xml
@@ -35,48 +35,14 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>get-zip-root-dir-path</id>
-                        <goals>
-                            <goal>regex-property</goal>
-                        </goals>
-                        <configuration>
-                            <name>zip.root.dir.path</name>
-                            <regex>.*/([^/]+/[^/]+)$</regex>
-                            <value>${project.basedir}</value>
-                            <replacement>$1</replacement>
-                            <failIfNoMatch>true</failIfNoMatch>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                    <descriptors>
-                        <descriptor>zip.xml</descriptor>
-                    </descriptors>
-                    <appendAssemblyId>false</appendAssemblyId>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>make-assembly</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <artifactId>maven-antrun-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <preparationGoals>clean install</preparationGoals>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/integrations/applications/traditional-web-application/pom.xml
+++ b/integrations/applications/traditional-web-application/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.integration.ui.templates</groupId>
         <artifactId>integration-templates</artifactId>
         <version>1.0.3-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     
     <name>traditional-web-application</name>

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -93,9 +93,12 @@
                             </goals>
                             <configuration>
                                 <target>
-                                    <mkdir dir="${zip.root.dir.path}" />
-                                    <zip destfile="${project.artifactId}-${project.version}.zip">
-                                        <fileset dir="resources" />
+                                    <mkdir dir="${project.build.directory}/templates/${zip.root.dir.path}" />
+                                    <copy todir="${project.build.directory}/templates/${zip.root.dir.path}">
+                                        <fileset dir="resources"/>
+                                    </copy>
+                                    <zip destfile="${project.build.directory}/${project.artifactId}-${project.version}.zip">
+                                        <fileset dir="${project.build.directory}/templates" />
                                     </zip>
                                 </target>
                             </configuration>

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -93,12 +93,12 @@
                             </goals>
                             <configuration>
                                 <target>
-                                    <mkdir dir="${project.build.directory}/templates/${zip.root.dir.path}" />
-                                    <copy todir="${project.build.directory}/templates/${zip.root.dir.path}">
+                                    <mkdir dir="${project.build.directory}/template/${zip.root.dir.path}" />
+                                    <copy todir="${project.build.directory}/template/${zip.root.dir.path}">
                                         <fileset dir="resources"/>
                                     </copy>
                                     <zip destfile="${project.build.directory}/${project.artifactId}-${project.version}.zip">
-                                        <fileset dir="${project.build.directory}/templates" />
+                                        <fileset dir="${project.build.directory}/template" />
                                     </zip>
                                 </target>
                             </configuration>

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -60,4 +60,58 @@
         <module>applications/traditional-web-application</module>
     </modules>
 
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>get-zip-root-dir-path</id>
+                            <goals>
+                                <goal>regex-property</goal>
+                            </goals>
+                            <configuration>
+                                <name>zip.root.dir.path</name>
+                                <regex>.*/([^/]+/[^/]+)$</regex>
+                                <value>${project.basedir}</value>
+                                <replacement>$1</replacement>
+                                <failIfNoMatch>true</failIfNoMatch>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>run</goal>
+                            </goals>
+                            <configuration>
+                                <target>
+                                    <mkdir dir="${zip.root.dir.path}" />
+                                    <zip destfile="${project.artifactId}-${project.version}.zip">
+                                        <fileset dir="resources" />
+                                    </zip>
+                                </target>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <configuration>
+                        <preparationGoals>clean install</preparationGoals>
+                        <autoVersionSubmodules>true</autoVersionSubmodules>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
 </project>


### PR DESCRIPTION
## Purpose
- Replace the `maven-assembly-plugin` with the `maven-antrun-plugin` for zipping tasks.
- Update the parent POM relative paths in the child POMs.
- Consolidate all plugin configurations in the parent POM for reuse and easier maintenance.

## Related Issue
- https://github.com/wso2/product-is/issues/20107