### PR TITLE
Remove the attribute name format configuration from SSO integration templates

### DIFF
--- a/integrations/applications/google/resources/info.json
+++ b/integrations/applications/google/resources/info.json
@@ -1,6 +1,6 @@
 {
     "id": "google",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "name": "Google Workspace",
     "description": "Google Workspace is a collection of cloud computing, productivity and collaboration tools, software and products developed and marketed by Google. It consists of Gmail, Contacts, Calendar, Meet and Chat for communication; Drive for storage; and the Google Docs Editors suite for content creation.",
     "image": "${CONSOLE_BASE_URL}/resources/connections/assets/images/logos/google.svg",

--- a/integrations/applications/google/resources/metadata.json
+++ b/integrations/applications/google/resources/metadata.json
@@ -161,7 +161,8 @@
                     "application-edit-inbound-saml-form-recipient",
                     "application-edit-inbound-saml-form-assertion-query-profile",
                     "application-edit-inbound-saml-form-certificate",
-                    "application-edit-inbound-saml-form-request-validation"
+                    "application-edit-inbound-saml-form-request-validation",
+                    "application-edit-inbound-saml-form-attribute-name-format"
                 ]
             },
             {

--- a/integrations/applications/microsoft-365/resources/info.json
+++ b/integrations/applications/microsoft-365/resources/info.json
@@ -1,6 +1,6 @@
 {
     "id": "microsoft-365",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "Microsoft 365",
     "description": "Microsoft 365 is a product family of productivity software, collaboration and cloud-based services owned by Microsoft.",
     "image": "${CONSOLE_BASE_URL}/resources/connections/assets/images/logos/microsoft.svg",

--- a/integrations/applications/microsoft-365/resources/metadata.json
+++ b/integrations/applications/microsoft-365/resources/metadata.json
@@ -148,7 +148,8 @@
                     "application-edit-inbound-saml-form-signature-validation-for-artifact-binding",
                     "application-edit-inbound-saml-form-audience",
                     "application-edit-inbound-saml-form-recipient",
-                    "application-edit-inbound-saml-form-assertion-query-profile"
+                    "application-edit-inbound-saml-form-assertion-query-profile",
+                    "application-edit-inbound-saml-form-attribute-name-format"
                 ]
             },
             {

--- a/integrations/applications/salesforce/resources/info.json
+++ b/integrations/applications/salesforce/resources/info.json
@@ -1,6 +1,6 @@
 {
     "id": "salesforce",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "Salesforce",
     "description": "Customer relationship management (CRM) platform that enables businesses to manage their sales, marketing, and customer service operations efficiently.",
     "image": "${CONSOLE_BASE_URL}/resources/applications/assets/images/illustrations/salesforce.png",

--- a/integrations/applications/salesforce/resources/metadata.json
+++ b/integrations/applications/salesforce/resources/metadata.json
@@ -148,7 +148,8 @@
                     "application-edit-inbound-saml-form-signature-validation-for-artifact-binding",
                     "application-edit-inbound-saml-form-audience",
                     "application-edit-inbound-saml-form-recipient",
-                    "application-edit-inbound-saml-form-assertion-query-profile"
+                    "application-edit-inbound-saml-form-assertion-query-profile",
+                    "application-edit-inbound-saml-form-attribute-name-format"
                 ]
             },
             {

--- a/integrations/applications/slack/resources/info.json
+++ b/integrations/applications/slack/resources/info.json
@@ -1,6 +1,6 @@
 {
     "id": "slack",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "Slack",
     "description": "Slack is a cloud-based messaging platform for team communication, offering channels, direct messaging, file sharing, and integrations with productivity tools to streamline collaboration and keep teams connected in real time.",
     "image": "${CONSOLE_BASE_URL}/resources/applications/assets/images/illustrations/slack.png",

--- a/integrations/applications/slack/resources/metadata.json
+++ b/integrations/applications/slack/resources/metadata.json
@@ -213,7 +213,8 @@
                     "application-edit-inbound-saml-form-idp-initiated-slo-heading",
                     "application-edit-inbound-saml-form-enable-idp-initiated-slo",
                     "application-edit-inbound-saml-form-slo-return-to-urls",
-                    "application-edit-inbound-saml-form-assertion-query-profile"
+                    "application-edit-inbound-saml-form-assertion-query-profile",
+                    "application-edit-inbound-saml-form-attribute-name-format"
                 ]
             },
             {

--- a/integrations/applications/zoom/resources/info.json
+++ b/integrations/applications/zoom/resources/info.json
@@ -1,6 +1,6 @@
 {
     "id": "zoom",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "Zoom",
     "description": "Zoom is a cloud-based platform for video communication and collaboration, offering tools like Zoom Meetings for video calls, Zoom Chat for messaging, and Zoom Webinars for virtual events.",
     "image": "${CONSOLE_BASE_URL}/resources/applications/assets/images/illustrations/zoom.svg",

--- a/integrations/applications/zoom/resources/metadata.json
+++ b/integrations/applications/zoom/resources/metadata.json
@@ -245,7 +245,8 @@
                     "application-edit-inbound-saml-form-recipient",
                     "application-edit-inbound-saml-form-attribute-profile-heading",
                     "application-edit-inbound-saml-form-enable-attribute-profile",
-                    "application-edit-inbound-saml-form-assertion-query-profile"
+                    "application-edit-inbound-saml-form-assertion-query-profile",
+                    "application-edit-inbound-saml-form-attribute-name-format"
                 ]
             },
             {


### PR DESCRIPTION
## Purpose
We recently introduced a configuration for SAML applications that allows users to select the attribute name format for attributes in a SAML assertion. However, this configuration is neither customizable nor supported by any of our current SSO integration providers. Therefore, we are hiding this field in SSO integrations for simplicity.

## Related Issue
- https://github.com/wso2/product-is/issues/4299