### PR TITLE
Enable shared access tab for mcp client applications

### DIFF
--- a/integrations/applications/mcp-client-application/resources/info.json
+++ b/integrations/applications/mcp-client-application/resources/info.json
@@ -1,6 +1,6 @@
 {
     "id": "mcp-client-application",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "name": "MCP Client Application",
     "description": "An application that needs a secure connection to an MCP Server.",
     "image": "${CONSOLE_BASE_URL}/resources/applications/assets/images/illustrations/mcp-template-illustration.svg",

--- a/integrations/applications/mcp-client-application/resources/metadata.json
+++ b/integrations/applications/mcp-client-application/resources/metadata.json
@@ -90,6 +90,9 @@
                 "id": "advanced"
             },
             {
+                "id": "shared-access"
+            },
+            {
                 "id": "info"
             }
         ],


### PR DESCRIPTION
## Purpose
$subject

## Goals
MCP client application gets to be shared to child organizations similar to other apps.

Related: https://github.com/wso2/product-is/issues/27525