### PR TITLE
Add agent application template

### DIFF
--- a/integrations/applications/agent-application/pom.xml
+++ b/integrations/applications/agent-application/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+  ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/integrations/applications/agent-application/pom.xml
+++ b/integrations/applications/agent-application/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.integration.ui.templates</groupId>
+        <artifactId>integration-templates</artifactId>
+        <version>1.1.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <name>agent-application</name>
+    <artifactId>org.wso2.carbon.identity.integration.ui.templates.applications.agent-application</artifactId>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
+    <url>http://wso2.org</url>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <skipAssembly>false</skipAssembly>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integrations/applications/agent-application/resources/info.json
+++ b/integrations/applications/agent-application/resources/info.json
@@ -1,0 +1,15 @@
+{
+    "id": "agent-application",
+    "version": "1.0.0",
+    "name": "Agent Application",
+    "description": "Applications tailored for AI agents",
+    "image": "",
+    "displayOrder": 0,
+    "category": "DEFAULT",
+    "tags": [
+        "Default",
+        "OAuth2"
+    ],
+    "type": "applications",
+    "customAttributes": []
+}

--- a/integrations/applications/agent-application/resources/metadata.json
+++ b/integrations/applications/agent-application/resources/metadata.json
@@ -1,0 +1,89 @@
+{
+    "create": {
+        "form": {
+            "fields": [
+                {
+                    "id": "application-name",
+                    "aria-label": "Application Name",
+                    "name": "name",
+                    "label": "Name",
+                    "type": "text",
+                    "required": true,
+                    "placeholder": "My Agent App",
+                    "dataComponentId": "agent-create-wizard-application-name",
+                    "handlers": [
+                        {
+                            "name": "applicationName",
+                            "type": "validation"
+                        }
+                    ]
+                },
+                {
+                    "id": "callback-url",
+                    "aria-label": "Authorized Redirect URL",
+                    "name": "inboundProtocolConfiguration.oidc.callbackURLs.[0]",
+                    "label": "Authorized Redirect URL",
+                    "type": "text",
+                    "required": true,
+                    "placeholder": "https://my-agent-app.io/callback",
+                    "dataComponentId": "agent-create-wizard-callback-url"
+                }
+            ]
+        }
+    },
+    "edit": {
+        "tabs": [
+            {
+                "id": "general",
+                "hiddenComponents": [
+                    "application-edit-general-details-form-image-url"
+                ]
+            },
+            {
+                "id": "protocol",
+                "displayName": "Protocol",
+                "hiddenComponents": [
+                    "application-edit-access-settings-inbound-oauth2-oidc-form-pushed-authorization-requests",
+                    "application-edit-access-settings-inbound-oauth2-oidc-form-request-object",
+                    "application-edit-access-settings-inbound-oauth2-oidc-form-hybrid-flow",
+                    "application-edit-access-settings-inbound-oauth2-oidc-form-access-token-type",
+                    "application-edit-access-settings-inbound-oauth2-oidc-form-access-token-binding-type",
+                    "application-edit-access-settings-inbound-oauth2-oidc-form-validate-token-binding",
+                    "application-edit-access-settings-inbound-oauth2-oidc-form-revoke-access-token-upon-user-logout",
+                    "application-edit-access-settings-inbound-oauth2-oidc-form-logout-urls",
+                    "application-edit-access-settings-inbound-oauth2-oidc-form-id-token-expiry-time",
+                    "application-edit-access-settings-inbound-oauth2-oidc-form-id-token-response-signing-algorithm",
+                    "application-edit-access-settings-inbound-oauth2-oidc-form-id-token-encryption",
+                    "application-edit-access-settings-inbound-oauth2-oidc-form-id-token-audience",
+                    "application-edit-access-settings-inbound-oauth2-oidc-form-id-token-encryption-algorithm",
+                    "application-edit-access-settings-inbound-oauth2-oidc-form-id-token-encryption-method"
+                ]
+            },
+            {
+                "id": "user-attributes",
+                "hiddenComponents": [
+                    "application-edit-user-attributes-linked-accounts",
+                    "application-edit-user-attributes--validate-linked-local-accounts",
+                    "application-edit-user-attributes-include-tenant-domain",
+                    "application-edit-user-attributes-include-user-domain"
+                ]
+            },
+            {
+                "id": "sign-in-method"
+            },
+            {
+                "id": "api-authorization"
+            },
+            {
+                "id": "application-roles"
+            },
+            {
+                "id": "advanced"
+            },
+            {
+                "id": "info"
+            }
+        ],
+        "defaultActiveTabId": "protocol"
+    }
+}

--- a/integrations/applications/agent-application/resources/template.json
+++ b/integrations/applications/agent-application/resources/template.json
@@ -1,0 +1,56 @@
+{
+  "payload": {
+    "name": "",
+    "advancedConfigurations": {
+      "discoverableByEndUsers": false,
+      "skipLogoutConsent": true,
+      "skipLoginConsent": true
+    },
+    "imageUrl": "",
+    "accessUrl": "",
+    "authenticationSequence": {
+      "type": "DEFAULT",
+      "steps": [
+        {
+          "id": 1,
+          "options": [
+            {
+              "idp": "LOCAL",
+              "authenticator": "basic"
+            }
+          ]
+        }
+      ]
+    },
+    "inboundProtocolConfiguration": {
+      "oidc": {
+        "grantTypes": [
+          "authorization_code",
+          "refresh_token",
+          "urn:openid:params:grant-type:ciba",
+          "urn:ietf:params:oauth:grant-type:token-exchange"
+        ],
+        "callbackURLs": [],
+        "allowedOrigins": [],
+        "publicClient": true,
+        "pkce": {
+          "mandatory": true,
+          "supportPlainTransformAlgorithm": false
+        },
+        "accessToken": {
+          "type": "Default",
+          "userAccessTokenExpiryInSeconds": 3600,
+          "applicationAccessTokenExpiryInSeconds": 3600,
+          "bindingType": "sso-session",
+          "revokeTokensWhenIDPSessionTerminated": true,
+          "validateTokenBinding": false
+        },
+        "refreshToken": {
+          "expiryInSeconds": 86400,
+          "renewRefreshToken": true
+        },
+        "hybridFlowResponseType": "code_idtoken"
+      }
+    }
+  }
+}

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -74,6 +74,7 @@
         <module>applications/expressjs-application</module>
         <module>applications/vue-application</module>
         <module>applications/digital-wallet-application</module>
+        <module>applications/agent-application</module>
     </modules>
 
     <build>


### PR DESCRIPTION
## Summary
  - Add new agent application template for AI agent integrations

  ## Changes
  - Added `agent-application` module to integrations
  - Created agent application template with metadata, form fields, and default OIDC configuration
  - Enabled grant types: authorization_code, refresh_token, CIBA, and token-exchange